### PR TITLE
BUGFIX: data race on master.pos

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -187,7 +187,7 @@ func (c *Canal) Close() {
 		c.syncer = nil
 	}
 
-	c.eventHandler.OnPosSynced(c.master.pos, true)
+	c.eventHandler.OnPosSynced(c.master.Position(), true)
 
 	c.wg.Wait()
 }


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Write at 0x00c420240558 by goroutine 23:
  github.com/uservoice/indexer/vendor/github.com/siddontang/go-mysql/canal.(*masterInfo).Update()
      /home/ubuntu/go/src/github.com/uservoice/indexer/vendor/github.com/siddontang/go-mysql/canal/master.go:22 +0x112
  github.com/uservoice/indexer/vendor/github.com/siddontang/go-mysql/canal.(*Canal).tryDump()
      /home/ubuntu/go/src/github.com/uservoice/indexer/vendor/github.com/siddontang/go-mysql/canal/dump.go:130 +0x777
  github.com/uservoice/indexer/vendor/github.com/siddontang/go-mysql/canal.(*Canal).run()
      /home/ubuntu/go/src/github.com/uservoice/indexer/vendor/github.com/siddontang/go-mysql/canal/canal.go:157 +0x7b

Previous read at 0x00c420240558 by goroutine 29:
  github.com/uservoice/indexer/vendor/github.com/siddontang/go-mysql/canal.(*Canal).Close()
      /home/ubuntu/go/src/github.com/uservoice/indexer/vendor/github.com/siddontang/go-mysql/canal/canal.go:186 +0x1a6
  github.com/uservoice/indexer/binlog.(*Stream).Stop()
      github.com/uservoice/indexer/binlog/_test/_obj_test/stream.go:553 +0x68
  github.com/uservoice/indexer/binlog.(*StreamManager).StopAll()
      github.com/uservoice/indexer/binlog/_test/_obj_test/stream_manager.go:145 +0x2cc
  github.com/uservoice/indexer/binlog.TestStreamManagerRemoveStream()
      /home/ubuntu/go/src/github.com/uservoice/indexer/binlog/stream_manager_test.go:82 +0x52f
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:746 +0x16c

Goroutine 23 (running) created at:
  github.com/uservoice/indexer/vendor/github.com/siddontang/go-mysql/canal.(*Canal).Start()
      /home/ubuntu/go/src/github.com/uservoice/indexer/vendor/github.com/siddontang/go-mysql/canal/canal.go:131 +0x69
  github.com/uservoice/indexer/binlog.(*Stream).Start()
      github.com/uservoice/indexer/binlog/_test/_obj_test/stream.go:540 +0x4fa
  github.com/uservoice/indexer/binlog.(*StreamManager).addRotation()
      github.com/uservoice/indexer/binlog/_test/_obj_test/stream_manager.go:49 +0x1a9
  github.com/uservoice/indexer/binlog.(*StreamManager).Add()
      github.com/uservoice/indexer/binlog/_test/_obj_test/stream_manager.go:92 +0x8d
  github.com/uservoice/indexer/binlog.(*StreamManager).StartAll()
      github.com/uservoice/indexer/binlog/_test/_obj_test/stream_manager.go:204 +0x8b3
  github.com/uservoice/indexer/binlog.TestStreamManagerRemoveStream()
      /home/ubuntu/go/src/github.com/uservoice/indexer/binlog/stream_manager_test.go:62 +0x111
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:746 +0x16c

Goroutine 29 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:789 +0x568
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1004 +0xa7
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:746 +0x16c
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1002 +0x521
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:921 +0x206
  main.main()
      github.com/uservoice/indexer/binlog/_test/_testmain.go:132 +0x2f0
==================
```